### PR TITLE
meson: Make unity support optional

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('libunity',
+       type : 'boolean',
+       value : true,
+       description : 'build with unity support')

--- a/src/controllers/AppController.vala
+++ b/src/controllers/AppController.vala
@@ -29,7 +29,9 @@ namespace App.Controllers {
         public App.Application application;
         public AppWindow window;
         public ViewController view_controller;
+#if LIBUNITY
         public Unity.LauncherEntry launcher;
+#endif
         public App.VGriveClient vgrive;
         public bool closed;
         public signal void log_event (string msg);
@@ -48,7 +50,9 @@ namespace App.Controllers {
             this.view_controller = new ViewController (this);
             // Connect the signals
             this.connect_signals();
+#if LIBUNITY
             this.launcher = Unity.LauncherEntry.get_for_desktop_id (Constants.LAUNCHER_ID);
+#endif
             if (vgrive.has_local_credentials()) {
                 if (vgrive.load_local_credentials() == 1) {
                     this.set_registered_view ("sync_view");
@@ -58,7 +62,9 @@ namespace App.Controllers {
 
         public void activate () {
             this.closed = false;
+#if LIBUNITY
             this.launcher.progress_visible = false;
+#endif
             // Show all elements from window
             window.init ();
             // Set current view
@@ -100,13 +106,17 @@ namespace App.Controllers {
                 if (this.vgrive.is_syncing ()) {
                     this.closed = true;
                     this.notify (_("Sync continues in background"));
+#if LIBUNITY
                     this.launcher.progress_visible = true;
                     this.launcher.progress = 0;
+#endif
                     return this.window.hide_on_delete ();
                 }else {
                     this.vgrive.stop_syncing ();
                     this.notify (_("Sync stopped"));
+#if LIBUNITY
                     this.launcher.progress_visible = false;
+#endif
                     return false;
                 }
             });

--- a/src/meson.build
+++ b/src/meson.build
@@ -25,9 +25,15 @@ deps = [
     dependency('gee-0.8'),
     dependency('json-glib-1.0'),
     dependency('libsoup-2.4'),
-    dependency('unity')
 ]
 
+libunity_dep = []
+if get_option('libunity')
+    add_project_arguments('-D', 'LIBUNITY', language: 'vala')
+    libunity_dep = [dependency('unity')]
+endif
+
+deps += libunity_dep
 
 executable(
     meson.project_name(),


### PR DESCRIPTION
Unity support is not available everywhere (Debian, Gentoo, ...)
Make Unity support optional but enabled by default.