### PR TITLE
Add Fedora installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ For debian based distributions (ubuntu, linux mint, elementary, ...) you can ins
 
 - https://github.com/bcedu/VGrive/releases
 
+### Fedora: Install from official repo
+
+- https://apps.fedoraproject.org/packages/vgrive
+
+- `sudo dnf install vgrive`
+
 ### Flatpak
 
 Install from flathub (aviable for any distro):


### PR DESCRIPTION
Packaged for Fedora 30+ and now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2019-273700b69d). Please add installation instructions. 